### PR TITLE
Bad-looking C code generated

### DIFF
--- a/crc_symtable.py
+++ b/crc_symtable.py
@@ -606,7 +606,7 @@ $if ($crc_reflect_in == Undefined) {:
         c = *data++;
 :}
         for (i = 0; i < 8; i++) {
-            bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask);:} $else {:crc & $cfg_msb_mask;:}
+            bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask):} $else {:crc & $cfg_msb_mask:};
             crc = (crc << 1) | ((c >> (7 - i)) & 0x01);
             if (bit) {
                 crc ^= $cfg_poly;
@@ -625,7 +625,7 @@ $crc_finalize_function_def$nop
     $c_bool bit;
 
     for (i = 0; i < $cfg_width; i++) {
-        bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask);:} $else {:crc & $cfg_msb_mask;:}
+        bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask):} $else {:crc & $cfg_msb_mask:};
         crc = (crc << 1) | 0x00;
         if (bit) {
             crc ^= $cfg_poly;
@@ -678,7 +678,7 @@ $if ($crc_reflect_in == True) {:
 :} $else {:
         for (i = 0x80; i > 0; i >>= 1) {
 :}
-            bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask);:} $else {:crc & $cfg_msb_mask;:}
+            bit = $if ($c_std == C89) {:!!(crc & $cfg_msb_mask):} $else {:crc & $cfg_msb_mask:};
             if (c & i) {
                 bit = !bit;
             }


### PR DESCRIPTION
Currently pycrc generates bad-looking C code like this:

```
for (i = 0; i < 32; i++) {
    bit = crc & 0x80000000;        crc = (crc << 1) | 0x00;
```

This bug was introduced in 0.7.9. The parser eats newline characters
after block delimiters, so a double-newline is necessary. This patch
fixes it.
