### PR TITLE
Reflection of xor-in when reflect_out is set

### DIFF
--- a/pycrc/algorithms.py
+++ b/pycrc/algorithms.py
@@ -81,8 +81,12 @@ class Crc(object):
             self.tbl_idx_width = 8
             self.tbl_width = 1 << self.tbl_idx_width
 
-        self.direct_init = self.xor_in
-        self.nondirect_init = self.__get_nondirect_init(self.xor_in)
+        if self.reflect_out:
+            register_init = self.reflect(self.xor_in, self.width)
+        else:
+            register_init = self.xor_in
+        self.direct_init = register_init
+        self.nondirect_init = self.__get_nondirect_init(register_init)
         if self.width < 8:
             self.crc_shift = 8 - self.width
         else:

--- a/pycrc/main.py
+++ b/pycrc/main.py
@@ -162,7 +162,7 @@ def check_file(opt):
         reflect_out=opt.reflect_out, xor_out=opt.xor_out,
         table_idx_width=opt.tbl_idx_width)
 
-    if not opt.reflect_in:
+    if not opt.reflect_out:
         register = opt.xor_in
     else:
         register = alg.reflect(opt.xor_in, opt.width)


### PR DESCRIPTION
The xor-in value must be reflected whenever the reflect-out parameter
is set *not* the reflect-in: reflect-in only applies to individual
bytes in the input, reflect-out applies to the reflection of the
register. The reflection of xor-in was missing for strings (and
hex-strings) and was wrongly applied when reflect-in was set (not
reflect-out) for files.