### PR TITLE
No reflection of xor-in

### DIFF
--- a/pycrc/main.py
+++ b/pycrc/main.py
@@ -162,10 +162,9 @@ def check_file(opt):
         reflect_out=opt.reflect_out, xor_out=opt.xor_out,
         table_idx_width=opt.tbl_idx_width)
 
-    if not opt.reflect_in:
-        register = opt.xor_in
-    else:
-        register = alg.reflect(opt.xor_in, opt.width)
+    # Always use the xor_in value unreflected
+    # As in the rocksoft reference implementation
+    register = opt.xor_in
 
     try:
         with open(opt.check_file, 'rb') as f:


### PR DESCRIPTION
The check-file and check-string/check-hexstring versions didn't yield
the same results for a reflected (reflect-in = True) model. The
1993 reference implementation by Ross N. Williams does *never* reflect
xor-in.