### PR TITLE
Update MutableMapping import for Python 3.10

### DIFF
--- a/pycrc/symtable.py
+++ b/pycrc/symtable.py
@@ -36,7 +36,7 @@ use as follows:
 """
 
 from pycrc.algorithms import Crc
-import collections
+import collections.abc
 import time
 import os
 
@@ -46,7 +46,7 @@ class SymbolTable(object):
         self.opt = opt
 
 
-class SymbolTable(collections.MutableMapping):
+class SymbolTable(collections.abc.MutableMapping):
     """A dictionary that applies an arbitrary key-altering
        function before accessing the keys"""
 


### PR DESCRIPTION
The ABCs were moved to collections.abc in Python 3.3, but aliases were in the collections module to avoid breaking code.  Python 3.10 removed those aliases.

The Travis config in the repo declares compatibility with Python 3.2, which does not have collections.abc.  I don't know if this package still runs on 3.2, and virtualenv doesn't support 3.2 (according to its docs, I didn't try), so I couldn't test it on 3.2.  On the assumption that no one cares about 3.2 anymore, this commit does not catch ImportError and fall back to the old import.